### PR TITLE
wildcard for non-tor TBB's

### DIFF
--- a/etc/apparmor.d/home.tor-browser.firefox
+++ b/etc/apparmor.d/home.tor-browser.firefox
@@ -3,7 +3,7 @@
 
 @{TBB} = @{HOME}*
 
-/home/**/tor-browser*/Browser/firefox flags=(attach_disconnected) {
+/home/**/*-browser*/Browser/firefox flags=(attach_disconnected) {
     #include <abstractions/base>
     #include <abstractions/fonts>
     #include <abstractions/kde>
@@ -71,9 +71,9 @@
     @{HOME}/* r,
     ##################################################
 
-    owner @{TBB}/tor-browser*/** mrlwkix,
+    owner @{TBB}/*-browser*/** mrlwkix,
     ## Allow TBB installations in /home/user (not only /home/user/*/ )
-    owner @{HOME}/tor-browser*/** mrlwkix,
+    owner @{HOME}/*-browser*/** mrlwkix,
 
     ## KDE 4 ##
     @{HOME}/.kde/share/config/* r,

--- a/etc/apparmor.d/home.tor-browser.start-tor-browser
+++ b/etc/apparmor.d/home.tor-browser.start-tor-browser
@@ -3,7 +3,7 @@
 
 @{TBB} = @{HOME}*
 
-/home*/tor-browser*/{Browser/,}start-tor-browser flags=(attach_disconnected) {
+/home*/*-browser*/{Browser/,}start-*-browser flags=(attach_disconnected) {
   #include <abstractions/base>
   #include <abstractions/bash>
   #include <abstractions/fonts>
@@ -25,15 +25,15 @@
   /dev/tty rw,
   /etc/magic r,
 
-  owner @{TBB}/tor-browser*/Browser/*.so mr,
-  owner @{TBB}/tor-browser*/{Browser/TorBrowser/,}Tor/tor r,
-  owner @{TBB}/tor-browser*/{Browser/TorBrowser/,}Tor/*.so* mr,
-  owner @{TBB}/tor-browser*/{Browser/,}start-tor-browser r,
-  owner @{TBB}/tor-browser*/start-tor-browser.desktop rw,
-  owner @{TBB}/tor-browser*/Browser/start-tor-browser.desktop r,
-  owner @{TBB}/tor-browser*/Browser/dependentlibs.list r,
+  owner @{TBB}/*-browser*/Browser/*.so mr,
+  owner @{TBB}/*-browser*/{Browser/TorBrowser/,}Tor/tor r,
+  owner @{TBB}/*-browser*/{Browser/TorBrowser/,}Tor/*.so* mr,
+  owner @{TBB}/*-browser*/{Browser/,}start-*-browser r,
+  owner @{TBB}/*-browser*/start-*-browser.desktop rw,
+  owner @{TBB}/*-browser*/Browser/start-*-browser.desktop r,
+  owner @{TBB}/*-browser*/Browser/dependentlibs.list r,
   ## No slash for a child profile.
-  owner @{TBB}tor-browser*/Browser/firefox Px,
+  owner @{TBB}*-browser*/Browser/firefox Px,
 
   @{PROC}/ r,
   @{PROC}/[0-9]*/status r,

--- a/etc/apparmor.d/home.tor-browser.start-tor-browser
+++ b/etc/apparmor.d/home.tor-browser.start-tor-browser
@@ -3,7 +3,7 @@
 
 @{TBB} = @{HOME}*
 
-/home*/*-browser*/{Browser/,}start-*-browser flags=(attach_disconnected) {
+/home/**/*-browser*/{Browser/,}start-*-browser flags=(attach_disconnected) {
   #include <abstractions/base>
   #include <abstractions/bash>
   #include <abstractions/fonts>


### PR DESCRIPTION
This allows the same apparmor profile to be used for non-Tor or modified Browser Bundles, as long as they are in ~/\*/\*-browser/ folders. So for the i2p browser it's ~/.i2pb/i2p-browser, for a hypothetical ZeroNet browser it could be ~/.zerob/zeronet-browser/ etc.