### PR TITLE
Remove overridden rules on net/arp and net/route

### DIFF
--- a/etc/apparmor.d/home.tor-browser.firefox
+++ b/etc/apparmor.d/home.tor-browser.firefox
@@ -54,8 +54,6 @@
 
     @{PROC}/*/environ r,
     @{PROC}/@{pid}/status r,
-    @{PROC}/@{pid}/net/route r,
-    @{PROC}/@{pid}/net/arp r,
     @{PROC}/@{pid}/uid_map rw,
     @{PROC}/@{pid}/gid_map rw,
     @{PROC}/@{pid}/setgroups rw,


### PR DESCRIPTION
These are overridden by the corresponding `deny` rules several lines below.

See also: https://github.com/micahflee/torbrowser-launcher/commit/88d862a3828ef0b287232018e300dd6ce66b57a1